### PR TITLE
Avoids circular import

### DIFF
--- a/cspreports/models.py
+++ b/cspreports/models.py
@@ -3,9 +3,6 @@ from django.db import models
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
 
-# CSP REPORTS
-from cspreports import utils
-
 
 class CSPReport(models.Model):
 
@@ -18,6 +15,10 @@ class CSPReport(models.Model):
 
     def json_as_html(self):
         """ Print out self.json in a nice way. """
+
+        # To avoid circular import
+        from cspreports import utils
+
         formatted_json = utils.format_report(self.json)
         return mark_safe(u"<pre>\n%s</pre>" % escape(formatted_json))
 


### PR DESCRIPTION
When having `'cspreports'` on installed apps, triggers a circular import between `models.py` and `utils.py`,