### PR TITLE
Revert removing data property which is still used

### DIFF
--- a/cspreports/models.py
+++ b/cspreports/models.py
@@ -1,3 +1,6 @@
+# STANDARD LIB
+import json
+
 #LIBRARIES
 from django.db import models
 from django.utils.html import escape
@@ -12,6 +15,15 @@ class CSPReport(models.Model):
     created = models.DateTimeField(auto_now_add=True)
     modified = models.DateTimeField(auto_now=True)
     json = models.TextField()
+
+    @property
+    def data(self):
+        """ Returns self.json loaded as a python object. """
+        try:
+            data = self._data
+        except AttributeError:
+            data = self._data = json.loads(self.json)
+        return data
 
     def json_as_html(self):
         """ Print out self.json in a nice way. """


### PR DESCRIPTION
This was removed in b1bc34e9a83cb3af5dd11baa1236f2b65ab823f9 but is still used in [admin.py](https://github.com/adamalton/django-csp-reports/blob/master/cspreports/admin.py#L15).