### PR TITLE
remove deprecated django.utils.importlib

### DIFF
--- a/cspreports/utils.py
+++ b/cspreports/utils.py
@@ -5,7 +5,7 @@ import json
 # LIBRARIES
 from django.conf import settings
 from django.core.mail import mail_admins
-from django.utils.importlib import import_module
+from importlib import import_module
 
 # CSP REPORTS
 from cspreports.models import CSPReport


### PR DESCRIPTION
This removes the warning:

    RemovedInDjango19Warning: django.utils.importlib will be removed in Django 1.9.

See http://stackoverflow.com/q/29931979/5127629