### PR TITLE
Setup Travis CI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 120
+exclude = */migrations/*
+max-complexity = 12

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/Makefile whitespace=space-before-tab,indent-with-non-tab,tabwidth=4

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+/.eggs
 
 # Installer logs
 pip-log.txt

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,4 @@
+[settings]
+line_length = 120
+combine_as_imports = true
+known_first_party = cspreports

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+sudo: false
+python:
+  - "2.7"
+env:
+  - TOX_ENV=quality
+  - TOX_ENV=py27-18
+  - TOX_ENV=py27-19
+  - TOX_ENV=py27-110
+  - TOX_ENV=py27-111
+install:
+  - pip install tox
+script:
+  - tox -e $TOX_ENV

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,13 @@
-.PHONY: isort check-isort check-flake8
+.PHONY: test coverage isort check-isort check-flake8
+
+test:
+	python runtests.py
+
+coverage:
+	python-coverage erase
+	-rm -r htmlcov
+	python-coverage run --branch --source="." runtests.py
+	python-coverage html -d htmlcov
 
 isort:
 	isort --recursive cspreports

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: isort check-isort check-flake8
+
+isort:
+	isort --recursive cspreports
+
+check-isort:
+	isort --check-only --diff --recursive cspreports
+
+check-flake8:
+	flake8 --format=pylint cspreports

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,17 @@
+[[source]]
+
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "pypi"
+
+
+[dev-packages]
+
+"flake8" = "*"
+isort = "*"
+mock = "*"
+
+
+[packages]
+
+django = ">=1.8,<1.11.99"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,135 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "4c448c56dd39ab34d87f2166cd9c48c9f3ca3216a3ce5f9476cf0118743220ef"
+        },
+        "host-environment-markers": {
+            "implementation_name": "cpython",
+            "implementation_version": "0",
+            "os_name": "posix",
+            "platform_machine": "x86_64",
+            "platform_python_implementation": "CPython",
+            "platform_release": "4.13.0-1-amd64",
+            "platform_system": "Linux",
+            "platform_version": "#1 SMP Debian 4.13.13-1 (2017-11-16)",
+            "python_full_version": "2.7.14",
+            "python_version": "2.7",
+            "sys_platform": "linux2"
+        },
+        "pipfile-spec": 6,
+        "requires": {},
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.python.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "django": {
+            "hashes": [
+                "sha256:fad46f44f6f4de66aacaa92e7753dbc4fe3ae834aa2daffaca0bf16c64798186",
+                "sha256:fed3e79bb5a3a8d5eb054c7a1ec1de229ef3f43335a67821cc3e489e9582f711"
+            ],
+            "version": "==1.11.8"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:80af0f3008046b9975242012a985f04c5df1f01eed4ec1633d56cc47a75a6a48",
+                "sha256:feb2365914948b8620347784b6b6da356f31c9d03560259070b2f30cff3d469d",
+                "sha256:59707844a9825589878236ff2f4e0dc9958511b7ffaae94dc615da07d4a68d33",
+                "sha256:d0ef5ef55ed3d37854320d4926b04a4cb42a2e88f71da9ddfdacfde8e364f027",
+                "sha256:c41c62827ce9cafacd6f2f7018e4f83a6f1986e87bfd000b8cfbd4ab5da95f1a",
+                "sha256:8cc90340159b5d7ced6f2ba77694d946fc975b09f1a51d93f3ce3bb399396f94",
+                "sha256:dd2e4ca6ce3785c8dd342d1853dd9052b19290d5bf66060846e5dc6b8d6667f7",
+                "sha256:699d18a2a56f19ee5698ab1123bbcc1d269d061996aeb1eda6d89248d3542b82",
+                "sha256:fae4cffc040921b8a2d60c6cf0b5d662c1190fe54d718271db4eb17d44a185b7"
+            ],
+            "version": "==2017.3"
+        }
+    },
+    "develop": {
+        "configparser": {
+            "hashes": [
+                "sha256:5308b47021bc2340965c371f0f058cc6971a04502638d4244225c49d80db273a"
+            ],
+            "markers": "python_version < '3.2'",
+            "version": "==3.5.0"
+        },
+        "enum34": {
+            "hashes": [
+                "sha256:6bd0f6ad48ec2aa117d3d141940d484deccda84d4fcd884f5c3d93c23ecd8c79",
+                "sha256:644837f692e5f550741432dd3f223bbb9852018674981b1664e5dc339387588a",
+                "sha256:8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1",
+                "sha256:2d81cbbe0e73112bdfe6ef8576f2238f2ba27dd0d55752a776c41d38b7da2850"
+            ],
+            "markers": "python_version < '3.4'",
+            "version": "==1.1.6"
+        },
+        "flake8": {
+            "hashes": [
+                "sha256:c7841163e2b576d435799169b78703ad6ac1bbb0f199994fc05f700b2a90ea37",
+                "sha256:7253265f7abd8b313e3892944044a365e3f4ac3fcdcfb4298f55ee9ddf188ba0"
+            ],
+            "version": "==3.5.0"
+        },
+        "funcsigs": {
+            "hashes": [
+                "sha256:330cc27ccbf7f1e992e69fef78261dc7c6569012cf397db8d3de0234e6c937ca",
+                "sha256:a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50"
+            ],
+            "markers": "python_version < '3.3'",
+            "version": "==1.0.2"
+        },
+        "isort": {
+            "hashes": [
+                "sha256:cd5d3fc2c16006b567a17193edf4ed9830d9454cbeb5a42ac80b36ea00c23db4",
+                "sha256:79f46172d3a4e2e53e7016e663cc7a8b538bec525c36675fcfd2767df30b3983"
+            ],
+            "version": "==4.2.15"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
+        },
+        "mock": {
+            "hashes": [
+                "sha256:5ce3c71c5545b472da17b72268978914d0252980348636840bd34a00b5cc96c1",
+                "sha256:b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba"
+            ],
+            "version": "==2.0.0"
+        },
+        "pbr": {
+            "hashes": [
+                "sha256:60c25b7dfd054ef9bb0ae327af949dd4676aa09ac3a9471cdc871d8a9213f9ac",
+                "sha256:05f61c71aaefc02d8e37c0a3eeb9815ff526ea28b3b76324769e6158d7f95be1"
+            ],
+            "version": "==3.1.1"
+        },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:6c4245ade1edfad79c3446fadfc96b0de2759662dc29d07d80a6f27ad1ca6ba9",
+                "sha256:682256a5b318149ca0d2a9185d365d8864a768a28db66a84a2ea946bcc426766"
+            ],
+            "version": "==2.3.1"
+        },
+        "pyflakes": {
+            "hashes": [
+                "sha256:08bd6a50edf8cffa9fa09a463063c425ecaaf10d1eb0335a7e8b1401aef89e6f",
+                "sha256:8d616a382f243dbf19b54743f280b80198be0bca3a5396f1d2e1fca6223e8805"
+            ],
+            "version": "==1.6.0"
+        },
+        "six": {
+            "hashes": [
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb",
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
+            ],
+            "version": "==1.11.0"
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It receives the reports from the browser and does any/all of the following with 
 
 ### Supported Django Versions
 
-Supports all versions of Django (up to 1.10 at time of writing).  For Django <=1.7 you will need to use the `urls_legacy.py` file instead of `urls.py`.
+Supports Django 1.8 to 1.11.
 
 
 ### How Do I Use This Thing?

--- a/cspreports/admin.py
+++ b/cspreports/admin.py
@@ -1,6 +1,5 @@
 from django.contrib import admin
 
-# SOCKET SHARE
 from cspreports.models import CSPReport
 
 
@@ -20,5 +19,6 @@ class CSPReportAdmin(admin.ModelAdmin):
 
     json_as_html.short_description = "Report"
     json_as_html.allow_tags = True
+
 
 admin.site.register(CSPReport, CSPReportAdmin)

--- a/cspreports/management/commands/clean_cspreports.py
+++ b/cspreports/management/commands/clean_cspreports.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.utils.dateparse import parse_date
 from django.utils.encoding import force_text
-from django.utils.timezone import localtime, make_aware
+from django.utils.timezone import localtime, make_aware, now
 
 from cspreports.models import CSPReport
 
@@ -32,7 +32,10 @@ def get_limit(value):
             limit = make_aware(limit)
         return limit
     else:
-        return localtime().replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(days=DEFAULT_OFFSET)
+        limit = now()
+        if settings.USE_TZ:
+            limit = localtime(limit)
+        return limit.replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(days=DEFAULT_OFFSET)
 
 
 class Command(BaseCommand):

--- a/cspreports/management/commands/clean_cspreports.py
+++ b/cspreports/management/commands/clean_cspreports.py
@@ -1,12 +1,13 @@
 """Command to clean old CSP reports."""
 from datetime import datetime, timedelta
 
-from cspreports.models import CSPReport
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.utils.dateparse import parse_date
 from django.utils.encoding import force_text
-from django.utils.timezone import get_current_timezone, localtime, make_aware
+from django.utils.timezone import localtime, make_aware
+
+from cspreports.models import CSPReport
 
 DEFAULT_OFFSET = 7
 

--- a/cspreports/migrations/0001_initial.py
+++ b/cspreports/migrations/0001_initial.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
+from django.db import migrations, models
 
 
 class Migration(migrations.Migration):

--- a/cspreports/migrations/0002_auto_20141011_1800.py
+++ b/cspreports/migrations/0002_auto_20141011_1800.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
+from django.db import migrations, models
 
 
 class Migration(migrations.Migration):

--- a/cspreports/tests/settings.py
+++ b/cspreports/tests/settings.py
@@ -1,0 +1,13 @@
+"""Settings for cspreports tests."""
+SECRET_KEY = 'CSP_REPORTS_TESTS'
+
+INSTALLED_APPS = [
+    'cspreports',
+]
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': ':memory:',
+    }
+}

--- a/cspreports/tests/test_commands.py
+++ b/cspreports/tests/test_commands.py
@@ -15,15 +15,15 @@ class TestGetLimit(SimpleTestCase):
     """Test `get_limit` function."""
 
     def test_none_aware(self):
-        with self.settings(USE_TZ=True):
+        with self.settings(USE_TZ=True, TIME_ZONE='UTC'):
             mock_now = datetime(2016, 4, 27, 12, 34, tzinfo=timezone.utc)
-            with patch('cspreports.management.commands.clean_cspreports.localtime', return_value=mock_now):
+            with patch('cspreports.management.commands.clean_cspreports.now', return_value=mock_now):
                 self.assertEqual(get_limit(None), datetime(2016, 4, 20, tzinfo=timezone.utc))
 
     def test_none_naive(self):
         with self.settings(USE_TZ=False):
             mock_now = datetime(2016, 4, 27, 12, 34)
-            with patch('cspreports.management.commands.clean_cspreports.localtime', return_value=mock_now):
+            with patch('cspreports.management.commands.clean_cspreports.now', return_value=mock_now):
                 self.assertEqual(get_limit(None), datetime(2016, 4, 20))
 
     def test_input_aware(self):

--- a/cspreports/tests/test_utils.py
+++ b/cspreports/tests/test_utils.py
@@ -1,16 +1,12 @@
-# STANDARD LIB
 from contextlib import nested
 
-# LIBRARIES
+import mock
 from django.http import HttpRequest
 from django.test import RequestFactory, TestCase
 from django.test.utils import override_settings
-import mock
 
-# CSP REPORTS
-from cspreports.models import CSPReport
 from cspreports import utils
-
+from cspreports.models import CSPReport
 
 JSON_CONTENT_TYPE = 'application/json'
 

--- a/cspreports/urls_legacy.py
+++ b/cspreports/urls_legacy.py
@@ -1,9 +1,0 @@
-from django.conf.urls import patterns, url
-from django.contrib import admin
-
-admin.autodiscover()
-
-urlpatterns = patterns(
-    'cspreports.views',
-    url(r'^report/$', 'report_csp', name='report_csp'),
-)

--- a/cspreports/urls_legacy.py
+++ b/cspreports/urls_legacy.py
@@ -1,8 +1,9 @@
 from django.conf.urls import patterns, url
-
 from django.contrib import admin
+
 admin.autodiscover()
 
-urlpatterns = patterns('cspreports.views',
+urlpatterns = patterns(
+    'cspreports.views',
     url(r'^report/$', 'report_csp', name='report_csp'),
 )

--- a/cspreports/utils.py
+++ b/cspreports/utils.py
@@ -1,15 +1,11 @@
-# STANDARD LIB
-import logging
 import json
-
-# LIBRARIES
-from django.conf import settings
-from django.core.mail import mail_admins
+import logging
 from importlib import import_module
 
-# CSP REPORTS
-from cspreports.models import CSPReport
+from django.conf import settings
+from django.core.mail import mail_admins
 
+from cspreports.models import CSPReport
 
 logger = logging.getLogger(getattr(settings, "CSP_REPORTS_LOGGER_NAME", "CSP Reports"))
 

--- a/runtests.py
+++ b/runtests.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+"""Script to run tests.
+
+This file is required to run Django tests in tox.
+Based on http://joebergantine.com/articles/reusable-django-application-travis-tox/
+"""
+import os
+import sys
+import django
+
+from django.conf import settings
+from django.test.utils import get_runner
+
+
+def runtests():
+    os.environ['DJANGO_SETTINGS_MODULE'] = 'cspreports.tests.settings'
+    django.setup()
+    TestRunner = get_runner(settings)
+    test_runner = TestRunner()
+    failures = test_runner.run_tests(['cspreports'])
+    sys.exit(bool(failures))
+
+
+if __name__ == '__main__':
+    runtests()

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,9 @@
 #!/usr/bin/env python
-
-from distutils.core import setup
-from setuptools import find_packages
+from setuptools import find_packages, setup
 
 PACKAGES = find_packages()
-
-EXTRAS = {
-    "test": ["mock"],
-}
+REQUIREMENTS = ['django >=1.8,<1.11.99']
+TEST_REQUIREMENTS = ['mock']
 
 setup(
     name='django-csp-reports',
@@ -22,9 +18,10 @@ setup(
     download_url='https://github.com/adamalton/django-csp-reports/tarball/1.1',
     packages=PACKAGES,
     include_package_data=True,
-    # dependencies
-    extras_require=EXTRAS,
-    tests_require=EXTRAS['test'],
+    python_requires='>=2.7,<3',
+    install_requires=REQUIREMENTS,
+    tests_require=TEST_REQUIREMENTS,
+    test_suite='runtests.runtests',
     keywords=['django', 'csp', 'content security policy'],
-    classifiers=['License :: OSI Approved :: MIT License', 'Framework :: Django']
-    )
+    classifiers=['License :: OSI Approved :: MIT License', 'Framework :: Django'],
+)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,28 @@
+[tox]
+envlist =
+    quality
+    py27-{18,19,110,111}
+
+# Generic specification for all unspecific environments
+[testenv]
+deps =
+    pipenv
+    18: django >= 1.8, < 1.8.99
+    19: django >= 1.9, < 1.9.99
+    110: django >= 1.10, < 1.10.99
+    111: django >= 1.11, < 1.11.99
+setenv = DJANGO_SETTINGS_MODULE = cspreports.tests.settings
+commands =
+    pipenv graph
+    python setup.py test
+
+# Specific environments
+[testenv:quality]
+whitelist_externals = make
+basepython = python2.7
+deps = pipenv
+commands =
+    pipenv install --dev
+    pipenv graph
+    make check-isort
+    make check-flake8


### PR DESCRIPTION
Setting up the Travis CI - fixes #15.

This required some other changes:
 * Add `Pipfile` and `Pipfile.lock`.
 * Clean imports and code to match isort and flake8 checks
 * Drop support for Django 1.7 and lower since it doesn't work any more.
 * Fix timezones in `clean_cspreports` command.
 * Update `setup.py`