### PR TITLE
Date utils

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,3 +2,4 @@
 line_length = 120
 combine_as_imports = true
 known_first_party = cspreports
+add_imports = from __future__ import unicode_literals

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,34 @@
 language: python
 sudo: false
 python:
-  - "2.7"
+  - "3.6"
+
 env:
   - TOX_ENV=quality
   - TOX_ENV=py27-18
   - TOX_ENV=py27-19
   - TOX_ENV=py27-110
   - TOX_ENV=py27-111
+  - TOX_ENV=py34-18
+  - TOX_ENV=py34-19
+  - TOX_ENV=py34-110
+  - TOX_ENV=py34-111
+  - TOX_ENV=py36-111
+# Because python3.5 image in Travis behaves weird we need to add python 3.5 runs explicitly to the matrix
+matrix:
+    include:
+      - python: 3.5
+        env:
+          - TOX_ENV=py35-18
+      - python: 3.5
+        env:
+          - TOX_ENV=py35-19
+      - python: 3.5
+        env:
+          - TOX_ENV=py35-110
+      - python: 3.5
+        env:
+          - TOX_ENV=py35-111
 install:
   - pip install tox
 script:

--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ name = "pypi"
 "flake8" = "*"
 isort = "*"
 mock = "*"
+six = "*"
 
 
 [packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4c448c56dd39ab34d87f2166cd9c48c9f3ca3216a3ce5f9476cf0118743220ef"
+            "sha256": "cad2b72d5f1681a43e7e07cafd4553219d7c462ff3d020a121f2517030702e48"
         },
         "host-environment-markers": {
             "implementation_name": "cpython",

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It receives the reports from the browser and does any/all of the following with 
 
 ### Supported Django Versions
 
-Supports Django 1.8 to 1.11.
+Supports Python 2.7, 3.4 to 3.7 and Django 1.8 to 1.11.
 
 
 ### How Do I Use This Thing?

--- a/cspreports/admin.py
+++ b/cspreports/admin.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.contrib import admin
 
 from cspreports.models import CSPReport

--- a/cspreports/apps.py
+++ b/cspreports/apps.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.apps import AppConfig
 
 

--- a/cspreports/management/commands/clean_cspreports.py
+++ b/cspreports/management/commands/clean_cspreports.py
@@ -1,43 +1,15 @@
 """Command to clean old CSP reports."""
 from __future__ import unicode_literals
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 
-from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
-from django.utils.dateparse import parse_date
 from django.utils.encoding import force_text
-from django.utils.timezone import localtime, make_aware, now
 
 from cspreports.models import CSPReport
+from cspreports.utils import get_midnight, parse_date_input
 
 DEFAULT_OFFSET = 7
-
-
-def get_limit(value):
-    """Returns limit datetime based on the user's input.
-
-    @param value: User's input or None
-    @type value: str
-    @raise ValueError: If the input is not valid.
-    """
-    limit = None
-    if value:
-        try:
-            limit = parse_date(value)
-        except ValueError:
-            limit = None
-        if limit is None:
-            raise ValueError("Limit is not a valid date: '{}'.".format(value))
-        limit = datetime(limit.year, limit.month, limit.day)
-        if settings.USE_TZ:
-            limit = make_aware(limit)
-        return limit
-    else:
-        limit = now()
-        if settings.USE_TZ:
-            limit = localtime(limit)
-        return limit.replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(days=DEFAULT_OFFSET)
 
 
 class Command(BaseCommand):
@@ -51,10 +23,15 @@ class Command(BaseCommand):
 
     def handle(self, **options):
         verbosity = options['verbosity']
-        try:
-            limit = get_limit(options['limit'])
-        except ValueError as err:
-            raise CommandError(force_text(err))
+
+        limit = options['limit']
+        if limit:
+            try:
+                limit = parse_date_input(limit)
+            except ValueError as err:
+                raise CommandError(force_text(err))
+        else:
+            limit = get_midnight() - timedelta(days=DEFAULT_OFFSET)
 
         CSPReport.objects.filter(created__lt=limit).delete()
         if verbosity >= 2:

--- a/cspreports/management/commands/clean_cspreports.py
+++ b/cspreports/management/commands/clean_cspreports.py
@@ -1,4 +1,6 @@
 """Command to clean old CSP reports."""
+from __future__ import unicode_literals
+
 from datetime import datetime, timedelta
 
 from django.conf import settings

--- a/cspreports/models.py
+++ b/cspreports/models.py
@@ -90,6 +90,7 @@ class CSPReport(models.Model):
         If the message is not valid, the result will still have as much fields set as possible.
 
         @param message: JSON encoded CSP report.
+        @type message: text
         """
         self = cls(json=message)
         try:
@@ -111,10 +112,11 @@ class CSPReport(models.Model):
             value = report_data.get(report_name)
             field = self._meta.get_field(field_name)
             min_value, max_value = connection.ops.integer_field_range(field.get_internal_type())
+            if min_value is None:
+                min_value = 0
             # All these fields are possitive. Value can't be negative.
             min_value = max(min_value, 0)
-            if value is not None and (min_value is None or min_value <= value) \
-                    and (max_value is None or value <= max_value):
+            if value is not None and min_value <= value and (max_value is None or value <= max_value):
                 setattr(self, field_name, value)
         # Extract disposition
         disposition = report_data.get('disposition')

--- a/cspreports/models.py
+++ b/cspreports/models.py
@@ -1,4 +1,6 @@
 # STANDARD LIB
+from __future__ import unicode_literals
+
 import json
 
 # LIBRARIES
@@ -149,4 +151,4 @@ class CSPReport(models.Model):
         from cspreports import utils
 
         formatted_json = utils.format_report(self.json)
-        return mark_safe(u"<pre>\n%s</pre>" % escape(formatted_json))
+        return mark_safe("<pre>\n%s</pre>" % escape(formatted_json))

--- a/cspreports/tests/settings.py
+++ b/cspreports/tests/settings.py
@@ -1,4 +1,6 @@
 """Settings for cspreports tests."""
+from __future__ import unicode_literals
+
 SECRET_KEY = 'CSP_REPORTS_TESTS'
 
 INSTALLED_APPS = [

--- a/cspreports/tests/test_commands.py
+++ b/cspreports/tests/test_commands.py
@@ -1,11 +1,11 @@
 """Test commands."""
 from datetime import datetime
-from StringIO import StringIO
 
 from django.core.management import CommandError, call_command
 from django.test import SimpleTestCase, TestCase, override_settings
 from django.utils import timezone
 from mock import patch
+from six import StringIO
 
 from cspreports.management.commands.clean_cspreports import get_limit
 from cspreports.models import CSPReport

--- a/cspreports/tests/test_commands.py
+++ b/cspreports/tests/test_commands.py
@@ -1,4 +1,6 @@
 """Test commands."""
+from __future__ import unicode_literals
+
 from datetime import datetime
 
 from django.core.management import CommandError, call_command

--- a/cspreports/tests/test_commands.py
+++ b/cspreports/tests/test_commands.py
@@ -4,45 +4,12 @@ from __future__ import unicode_literals
 from datetime import datetime
 
 from django.core.management import CommandError, call_command
-from django.test import SimpleTestCase, TestCase, override_settings
+from django.test import TestCase, override_settings
 from django.utils import timezone
 from mock import patch
 from six import StringIO
 
-from cspreports.management.commands.clean_cspreports import get_limit
 from cspreports.models import CSPReport
-
-
-class TestGetLimit(SimpleTestCase):
-    """Test `get_limit` function."""
-
-    def test_none_aware(self):
-        with self.settings(USE_TZ=True, TIME_ZONE='UTC'):
-            mock_now = datetime(2016, 4, 27, 12, 34, tzinfo=timezone.utc)
-            with patch('cspreports.management.commands.clean_cspreports.now', return_value=mock_now):
-                self.assertEqual(get_limit(None), datetime(2016, 4, 20, tzinfo=timezone.utc))
-
-    def test_none_naive(self):
-        with self.settings(USE_TZ=False):
-            mock_now = datetime(2016, 4, 27, 12, 34)
-            with patch('cspreports.management.commands.clean_cspreports.now', return_value=mock_now):
-                self.assertEqual(get_limit(None), datetime(2016, 4, 20))
-
-    def test_input_aware(self):
-        with self.settings(USE_TZ=True, TIME_ZONE='Europe/Prague'):
-            self.assertEqual(get_limit('2016-05-25'), timezone.make_aware(datetime(2016, 5, 25)))
-
-    def test_input_naive(self):
-        with self.settings(USE_TZ=False):
-            self.assertEqual(get_limit('2016-05-25'), datetime(2016, 5, 25))
-
-    def test_invalid_date(self):
-        with self.assertRaisesMessage(ValueError, 'Limit is not a valid date:'):
-            get_limit('2016-13-25')
-
-    def test_invalid_input(self):
-        with self.assertRaisesMessage(ValueError, 'Limit is not a valid date:'):
-            get_limit('INVALID')
 
 
 class TestCleanCspreports(TestCase):
@@ -64,20 +31,20 @@ class TestCleanCspreports(TestCase):
         call_command('clean_cspreports', verbosity=2, stdout=buff)
         self.assertIn('Deleted all reports ', buff.getvalue())
 
-    @override_settings(USE_TZ=True)
+    @override_settings(USE_TZ=True, TIME_ZONE='Europe/Prague')
     def test_clean(self):
         # Test reports are cleaned correctly
-        self.create_cspreport(datetime(2016, 4, 19, 23, 59, 59, tzinfo=timezone.utc))
-        self.create_cspreport(datetime(2016, 4, 20, 0, 0, 0, tzinfo=timezone.utc))
-        mock_now = datetime(2016, 4, 27, 12, 34, tzinfo=timezone.utc)
-        with patch('cspreports.management.commands.clean_cspreports.localtime', return_value=mock_now):
+        self.create_cspreport(datetime(2016, 4, 19, 21, 59, 59, tzinfo=timezone.utc))
+        self.create_cspreport(datetime(2016, 4, 19, 22, 0, 0, tzinfo=timezone.utc))
+        mock_now = datetime(2016, 4, 27, 0, 34, tzinfo=timezone.utc)
+        with patch('cspreports.utils.now', return_value=mock_now):
             call_command('clean_cspreports')
 
         self.assertQuerysetEqual(CSPReport.objects.values_list('created'),
-                                 [(datetime(2016, 4, 20, 0, 0, 0, tzinfo=timezone.utc), )],
+                                 [(datetime(2016, 4, 19, 22, 0, 0, tzinfo=timezone.utc), )],
                                  transform=tuple)
 
     def test_invalid(self):
         # Test invalid limit input
-        with self.assertRaisesMessage(CommandError, 'Limit is not a valid date:'):
+        with self.assertRaisesMessage(CommandError, "'JUNK' is not a valid date."):
             call_command('clean_cspreports', 'JUNK')

--- a/cspreports/tests/test_models.py
+++ b/cspreports/tests/test_models.py
@@ -1,4 +1,6 @@
 """Test for `cspreports.models`."""
+from __future__ import unicode_literals
+
 import json
 
 from django.test import SimpleTestCase

--- a/cspreports/tests/test_utils.py
+++ b/cspreports/tests/test_utils.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import mock
 from django.http import HttpRequest
 from django.test import RequestFactory, TestCase

--- a/cspreports/urls.py
+++ b/cspreports/urls.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.conf.urls import url
 from django.contrib import admin
 

--- a/cspreports/utils.py
+++ b/cspreports/utils.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import json
 import logging
 from importlib import import_module

--- a/cspreports/utils.py
+++ b/cspreports/utils.py
@@ -2,10 +2,13 @@ from __future__ import unicode_literals
 
 import json
 import logging
+from datetime import datetime
 from importlib import import_module
 
 from django.conf import settings
 from django.core.mail import mail_admins
+from django.utils.dateparse import parse_date
+from django.utils.timezone import localtime, make_aware, now
 
 from cspreports.models import CSPReport
 
@@ -93,3 +96,34 @@ def get_additional_handlers():
             handlers.append(function)
         _additional_handlers = handlers
     return _additional_handlers
+
+
+def parse_date_input(value):
+    """Return datetime based on the user's input.
+
+    @param value: User's input
+    @type value: str
+    @raise ValueError: If the input is not valid.
+    @return: Datetime of the beginning of the user's date.
+    """
+    try:
+        limit = parse_date(value)
+    except ValueError:
+        limit = None
+    if limit is None:
+        raise ValueError("'{}' is not a valid date.".format(value))
+    limit = datetime(limit.year, limit.month, limit.day)
+    if settings.USE_TZ:
+        limit = make_aware(limit)
+    return limit
+
+
+def get_midnight():
+    """Return last midnight in localtime as datetime.
+
+    @return: Midnight datetime
+    """
+    limit = now()
+    if settings.USE_TZ:
+        limit = localtime(limit)
+    return limit.replace(hour=0, minute=0, second=0, microsecond=0)

--- a/cspreports/utils.py
+++ b/cspreports/utils.py
@@ -49,7 +49,7 @@ def log_report(request):
 
 
 def save_report(request):
-    report = CSPReport.from_message(request.body)
+    report = CSPReport.from_message(request.body.decode(request.encoding or settings.DEFAULT_CHARSET))
     report.user_agent = request.META.get('HTTP_USER_AGENT', '')
     report.save()
 

--- a/cspreports/views.py
+++ b/cspreports/views.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,16 @@ from setuptools import find_packages, setup
 
 PACKAGES = find_packages()
 REQUIREMENTS = ['django >=1.8,<1.11.99']
-TEST_REQUIREMENTS = ['mock']
+TEST_REQUIREMENTS = ['mock', 'six']
+CLASSIFIERS = ['License :: OSI Approved :: MIT License',
+               'Framework :: Django',
+               'Programming Language :: Python',
+               'Programming Language :: Python :: 2',
+               'Programming Language :: Python :: 2.7',
+               'Programming Language :: Python :: 3',
+               'Programming Language :: Python :: 3.4',
+               'Programming Language :: Python :: 3.5',
+               'Programming Language :: Python :: 3.6']
 
 setup(
     name='django-csp-reports',
@@ -18,10 +27,10 @@ setup(
     download_url='https://github.com/adamalton/django-csp-reports/tarball/1.1',
     packages=PACKAGES,
     include_package_data=True,
-    python_requires='>=2.7,<3',
+    python_requires='>=2.7',
     install_requires=REQUIREMENTS,
     tests_require=TEST_REQUIREMENTS,
     test_suite='runtests.runtests',
     keywords=['django', 'csp', 'content security policy'],
-    classifiers=['License :: OSI Approved :: MIT License', 'Framework :: Django'],
+    classifiers=CLASSIFIERS,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,9 @@
 envlist =
     quality
     py27-{18,19,110,111}
+    py34-{18,19,110,111}
+    py35-{18,19,110,111}
+    py36-{111}
 
 # Generic specification for all unspecific environments
 [testenv]


### PR DESCRIPTION
Move utility functions for dates into `cspreports.utils`. Preparation for #21.

Notes: Branched from #26.