### PR TITLE
Drop admin autodiscover

### DIFF
--- a/cspreports/urls.py
+++ b/cspreports/urls.py
@@ -1,12 +1,8 @@
 from __future__ import unicode_literals
 
 from django.conf.urls import url
-from django.contrib import admin
 
 from .views import report_csp
-
-admin.autodiscover()
-
 
 urlpatterns = [
     url(r'^report/$', report_csp, name='report_csp'),


### PR DESCRIPTION
Running `autodiscover` was moved to a `AppConfig` long time ago.