### PR TITLE
Add Django 4.0 support. Drop older versions from CI setup.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,12 @@ dist: xenial
 language: python
 sudo: false
 python:
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
+  - "3.10"
 
 install:
   # tox-travis automatically splits the jobs

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It receives the reports from the browser and does any/all of the following with 
 
 ### Supported Django Versions
 
-Supports Python 3.5 to 3.8 and Django 1.11 to 3.x (latest).
+Supports Python 3.5 to 3.10 and Django 2.2 to 4.x (latest).
 
 Python 2.7 support is available in version 1.4 and/or the `python2.7-support` branch.
 

--- a/cspreports/management/commands/clean_cspreports.py
+++ b/cspreports/management/commands/clean_cspreports.py
@@ -2,7 +2,7 @@
 from datetime import timedelta
 
 from django.core.management.base import BaseCommand, CommandError
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from cspreports.models import CSPReport
 from cspreports.utils import get_midnight, parse_date_input
@@ -27,7 +27,7 @@ class Command(BaseCommand):
             try:
                 limit = parse_date_input(limit)
             except ValueError as err:
-                raise CommandError(force_text(err))
+                raise CommandError(force_str(err))
         else:
             limit = get_midnight() - timedelta(days=DEFAULT_OFFSET)
 

--- a/cspreports/management/commands/make_csp_summary.py
+++ b/cspreports/management/commands/make_csp_summary.py
@@ -2,7 +2,7 @@
 from datetime import timedelta
 
 from django.core.management.base import BaseCommand, CommandError
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from cspreports.summary import DEFAULT_TOP, collect
 from cspreports.utils import get_midnight, parse_date_input
@@ -14,7 +14,7 @@ def _parse_date_input(date_input, default_offset=0):
         try:
             return parse_date_input(date_input)
         except ValueError as err:
-            raise CommandError(force_text(err))
+            raise CommandError(force_str(err))
     else:
         return get_midnight() - timedelta(days=default_offset)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 VERSION = "1.6"
 
 PACKAGES = find_packages()
-REQUIREMENTS = ['django >=1.11,<4.0']
+REQUIREMENTS = ['django >=2.2,<5.0']
 TEST_REQUIREMENTS = ['coverage']
 EXTRAS_REQUIRE = {
     'quality': ['isort', 'flake8'],
@@ -19,7 +19,9 @@ CLASSIFIERS = ['License :: OSI Approved :: MIT License',
                'Programming Language :: Python :: 3.5',
                'Programming Language :: Python :: 3.6',
                'Programming Language :: Python :: 3.7',
-               'Programming Language :: Python :: 3.8']
+               'Programming Language :: Python :: 3.8',
+               'Programming Language :: Python :: 3.9',
+               'Programming Language :: Python :: 3.10']
 
 
 DESCRIPTION = (

--- a/tox.ini
+++ b/tox.ini
@@ -1,24 +1,25 @@
 [tox]
 envlist =
     quality
-    py35-{111,21,22}
-    py36-{111,21,22}
-    py37-{111,21,22}
-    py38-{22,30}
+    py35-{22}
+    py36-{22,30}
+    py37-{22,30}
+    py38-{22,30,40}
+    py39-{30,40}
+    py310-{30,40}
 
-# tox-travis block: mark quality as part of the python3.6 build
+# tox-travis block: mark quality as part of the python3.10 build
 [travis]
 python =
-    3.6: py36, quality
+    3.10: py310, quality
 
 # Generic specification for all unspecific environments
 [testenv]
 deps =
     codecov
-    111: django >= 1.11, < 1.11.99
-    21: django >= 2.1, < 2.2
     22: django >= 2.2.8, < 2.3
     30: django >= 3.0.5, <4.0
+    40: django >= 4.0, <5.0
 extras = test
 passenv = CI TRAVIS TRAVIS_*
 setenv = DJANGO_SETTINGS_MODULE = cspreports.tests.settings
@@ -29,7 +30,7 @@ commands =
 # Specific environments
 [testenv:quality]
 whitelist_externals = make
-basepython = python3.6
+basepython = python3.10
 extras = quality
 commands =
     make check-isort


### PR DESCRIPTION
This now makes the combinations of Python and Django versions that we test the same as the combinations that Django currently supports.

Fixes #49.