### PR TITLE
Fix: support for the allow_tags attribute is removed

### DIFF
--- a/cspreports/admin.py
+++ b/cspreports/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.utils.html import format_html
 
 from cspreports.models import CSPReport
 
@@ -9,7 +10,7 @@ class CSPReportAdmin(admin.ModelAdmin):
     readonly_fields = ('created', 'modified', 'json_as_html')
 
     def json_as_html(self, instance):
-        return "<br />" + instance.json_as_html()
+        return format_html("<br />" + instance.json_as_html())
 
     def document_uri(self, instance):
         return instance.data.get('csp-report', {}).get('document-uri')
@@ -18,7 +19,6 @@ class CSPReportAdmin(admin.ModelAdmin):
         return instance.data.get('csp-report', {}).get('blocked-uri')
 
     json_as_html.short_description = "Report"
-    json_as_html.allow_tags = True
 
 
 admin.site.register(CSPReport, CSPReportAdmin)


### PR DESCRIPTION
Support for the `allow_tags` attribute on `ModelAdmin` methods [was removed in Django 2.0](https://docs.djangoproject.com/en/4.0/releases/2.0/#features-removed-in-2-0). This PR fixes the issue.

---

Now
<img width="490" alt="before" src="https://user-images.githubusercontent.com/2833663/152503371-3942b8b7-bcd8-4b5d-93b0-b638ce66aaae.png">

After the fix
<img width="490" alt="after" src="https://user-images.githubusercontent.com/2833663/152503431-4a4376e1-0240-4a6e-9e0a-06e3ad32386e.png">