### PR TITLE
Allow usage of a custom csp report model

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,22 @@ Python 2.7 support is available in version 1.4 and/or the `python2.7-support` br
       - If set, the specificed function is passed each `HttpRequest` object of the CSP report before it's processed. Only requests for which the function returns `True` are processed.
       - You may want to set this to `"cspreports.filters.filter_browser_extensions"` as a starting point.
     * `CSP_REPORTS_LOGGER_NAME` (`str` defaults to `CSP Reports`). Specifies the logger name that will be used for logging CSP reports, if enabled.
+    * `CSP_REPORTS_MODEL` (`<app_label>.<model_name>` defaults to `"cspreports.CSPReport"`). Specifies the model to be used for storing the CSP reports. You can easily extend the model by implementing the abstract base class `cspreports.models.CSPReportBase` and adding your additional fields to it:
+
+      ```python
+      # your_app.model.py
+      from cspreports.models import CSPReportBase
+
+      class CustomCSPReport(CSPReportBase):
+          # Add your fields here
+          pass
+      ```
+
+      ```python
+      # settings.py
+
+      CSP_REPORTS_MODEL = "your_app.CustomCSPReport"
+      ```
 6. Set a cron to generate summaries.
 7. Enjoy.
 

--- a/cspreports/admin.py
+++ b/cspreports/admin.py
@@ -1,6 +1,9 @@
 from django.contrib import admin
 
-from cspreports.models import CSPReport
+from cspreports.models import get_report_model
+
+
+CSPReport = get_report_model()
 
 
 class CSPReportAdmin(admin.ModelAdmin):

--- a/cspreports/conf.py
+++ b/cspreports/conf.py
@@ -34,5 +34,9 @@ class Settings:
     def FILTER_FUNCTION(self):
         return getattr(settings, "CSP_REPORTS_FILTER_FUNCTION", None)
 
+    @property
+    def CSP_REPORT_MODEL(self):
+        return getattr(settings, "CSP_REPORTS_MODEL", "cspreports.CSPReport")
+
 
 app_settings = Settings()

--- a/cspreports/management/commands/clean_cspreports.py
+++ b/cspreports/management/commands/clean_cspreports.py
@@ -4,8 +4,10 @@ from datetime import timedelta
 from django.core.management.base import BaseCommand, CommandError
 from django.utils.encoding import force_str
 
-from cspreports.models import CSPReport
+from cspreports.models import get_report_model
 from cspreports.utils import get_midnight, parse_date_input
+
+CSPReport = get_report_model()
 
 DEFAULT_OFFSET = 7
 

--- a/cspreports/summary.py
+++ b/cspreports/summary.py
@@ -4,8 +4,10 @@ from urllib.parse import urlsplit, urlunsplit
 
 from django.template.loader import get_template
 
-from cspreports.models import CSPReport
+from cspreports.models import get_report_model
 
+
+CSPReport = get_report_model()
 DEFAULT_TOP = 10
 
 

--- a/cspreports/tests/models.py
+++ b/cspreports/tests/models.py
@@ -1,0 +1,5 @@
+from cspreports.models import CSPReportBase
+
+
+class CustomCSPReport(CSPReportBase):
+    pass

--- a/cspreports/tests/settings.py
+++ b/cspreports/tests/settings.py
@@ -3,6 +3,7 @@ SECRET_KEY = 'CSP_REPORTS_TESTS'
 
 INSTALLED_APPS = [
     'cspreports',
+    'cspreports.tests',
 ]
 
 DATABASES = {
@@ -18,3 +19,5 @@ TEMPLATES = [
         'APP_DIRS': True,
     },
 ]
+
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'

--- a/cspreports/tests/test_custom_model.py
+++ b/cspreports/tests/test_custom_model.py
@@ -1,0 +1,46 @@
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from django.test import TestCase, override_settings
+from django.test.signals import setting_changed
+
+from cspreports.models import get_report_model
+from cspreports.conf import app_settings
+from cspreports.tests.models import CustomCSPReport
+
+
+class TestGetReportModelModel(TestCase):
+    @override_settings(CSP_REPORTS_MODEL="tests.CustomCSPReport")
+    def test_custom_get_report_model(self):
+        """Test get_report_model with a custom report model"""
+        self.assertIs(get_report_model(), CustomCSPReport)
+
+    @override_settings(CSP_REPORTS_MODEL="tests.CustomCSPReport")
+    def test_custom_get_report_model_string(self):
+        """Test model string with a custom report model"""
+        self.assertEqual(app_settings.CSP_REPORT_MODEL, "tests.CustomCSPReport")
+
+    @override_settings()
+    def test_standard_get_report_model(self):
+        """Test get_report_model with no CSP_REPORTS_MODEL"""
+        del settings.CSP_REPORTS_MODEL
+        from cspreports.models import CSPReport
+
+        self.assertIs(get_report_model(), CSPReport)
+
+    @override_settings()
+    def test_standard_get_report_model_string(self):
+        """Test model string with no CSP_REPORTS_MODEL"""
+        del settings.CSP_REPORTS_MODEL
+        self.assertEqual(app_settings.CSP_REPORT_MODEL, "cspreports.CSPReport")
+
+    @override_settings(CSP_REPORTS_MODEL="tests.UnknownModel")
+    def test_unknown_get_report_model(self):
+        """Test get_report_model with an unknown model"""
+        with self.assertRaises(ImproperlyConfigured):
+            get_report_model()
+
+    @override_settings(CSP_REPORTS_MODEL="invalid-string")
+    def test_invalid_get_report_model(self):
+        """Test get_report_model with an invalid model string"""
+        with self.assertRaises(ImproperlyConfigured):
+            get_report_model()

--- a/cspreports/utils.py
+++ b/cspreports/utils.py
@@ -8,8 +8,10 @@ from django.core.mail import mail_admins
 from django.utils.dateparse import parse_date
 from django.utils.timezone import localtime, make_aware, now
 
-from cspreports.models import CSPReport
+from cspreports.models import get_report_model
 from cspreports.conf import app_settings
+
+CSPReport = get_report_model()
 
 logger = logging.getLogger(app_settings.LOGGER_NAME)
 


### PR DESCRIPTION
See issue #56

- split report model into base model and implementation
- add  setting `CSP_REPORTS_MODEL` to specify which model to use as report model
- add and use `get_report_model` which loads the model based on new setting `CSP_REPORTS_MODEL`
- and tests

Contains no breaking changes.