### PR TITLE
Removed default_app_config variable

### DIFF
--- a/cspreports/__init__.py
+++ b/cspreports/__init__.py
@@ -1,2 +1,1 @@
-# STANDARD LIB
-default_app_config = 'cspreports.apps.CSPReportsConfig'
+


### PR DESCRIPTION
The default_app_config variable is marked as deprecated in Django 3.2.x and removed in Django 4.x, which detects this configuration automatically. [Reference](https://docs.djangoproject.com/en/3.2/releases/3.2/#automatic-appconfig-discovery)