### PR TITLE
uifix: remove br as useless and removing advantage of nested mark_safe

### DIFF
--- a/cspreports/admin.py
+++ b/cspreports/admin.py
@@ -12,7 +12,7 @@ class CSPReportAdmin(admin.ModelAdmin):
     readonly_fields = ('created', 'modified', 'json_as_html')
 
     def json_as_html(self, instance):
-        return "<br />" + instance.json_as_html()
+        return instance.json_as_html()
 
     def document_uri(self, instance):
         return instance.data.get('csp-report', {}).get('document-uri')


### PR DESCRIPTION
The html-ize json was not considered as html as concatenated with a string without re-using mark_safe. I just removed the <br/> and it looks good to me

best,