### PR TITLE
Adds support for django 5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It receives the reports from the browser and does any/all of the following with 
 
 ### Supported Django Versions
 
-Supports Python 3.5 to 3.10 and Django 2.2 to 4.x (latest).
+Supports Python 3.5 to 3.10 and Django 2.2 to 5.x (latest).
 
 Python 2.7 support is available in version 1.4 and/or the `python2.7-support` branch.
 

--- a/cspreports/tests/test_commands.py
+++ b/cspreports/tests/test_commands.py
@@ -1,5 +1,5 @@
 """Test commands."""
-from datetime import datetime
+from datetime import datetime, timezone as dt_timezone
 from io import StringIO
 from unittest.mock import patch
 
@@ -34,14 +34,14 @@ class TestCleanCspreports(TestCase):
     @override_settings(USE_TZ=True, TIME_ZONE='Europe/Prague')
     def test_clean(self):
         # Test reports are cleaned correctly
-        self.create_cspreport(datetime(2016, 4, 19, 21, 59, 59, tzinfo=timezone.utc))
-        self.create_cspreport(datetime(2016, 4, 19, 22, 0, 0, tzinfo=timezone.utc))
-        mock_now = datetime(2016, 4, 27, 0, 34, tzinfo=timezone.utc)
+        self.create_cspreport(datetime(2016, 4, 19, 21, 59, 59, tzinfo=dt_timezone.utc))
+        self.create_cspreport(datetime(2016, 4, 19, 22, 0, 0, tzinfo=dt_timezone.utc))
+        mock_now = datetime(2016, 4, 27, 0, 34, tzinfo=dt_timezone.utc)
         with patch('cspreports.utils.now', return_value=mock_now):
             call_command('clean_cspreports')
 
-        self.assertQuerysetEqual(CSPReport.objects.values_list('created'),
-                                 [(datetime(2016, 4, 19, 22, 0, 0, tzinfo=timezone.utc), )],
+        self.assertQuerySetEqual(CSPReport.objects.values_list('created'),
+                                 [(datetime(2016, 4, 19, 22, 0, 0, tzinfo=dt_timezone.utc), )],
                                  transform=tuple)
 
     def test_invalid(self):

--- a/cspreports/tests/test_utils.py
+++ b/cspreports/tests/test_utils.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import datetime, timezone as dt_timezone
 from unittest.mock import patch
 
 from django.http import HttpRequest
@@ -158,9 +158,9 @@ class TestGetMidnight(SimpleTestCase):
     def test_aware(self):
         with self.settings(USE_TZ=True, TIME_ZONE='Europe/Prague'):
             # 00:05 in CEST is 22:05 day before in UTC
-            mock_now = datetime(2016, 4, 26, 22, 5, tzinfo=timezone.utc)
+            mock_now = datetime(2016, 4, 26, 22, 5, tzinfo=dt_timezone.utc)
             with patch('cspreports.utils.now', return_value=mock_now):
-                self.assertEqual(get_midnight(), datetime(2016, 4, 26, 22, 0, tzinfo=timezone.utc))
+                self.assertEqual(get_midnight(), datetime(2016, 4, 26, 22, 0, tzinfo=dt_timezone.utc))
 
     def test_naive(self):
         with self.settings(USE_TZ=False):
@@ -180,7 +180,7 @@ class SaveReportTest(TestCase):
         utils.save_report(request)
 
         reports = CSPReport.objects.all()
-        self.assertQuerysetEqual(reports.values_list('user_agent'), [('Agent007', )], transform=tuple)
+        self.assertQuerySetEqual(reports.values_list('user_agent'), [('Agent007', )], transform=tuple)
         report = reports[0]
         self.assertEqual(report.json, body)
         self.assertFalse(report.is_valid)
@@ -193,7 +193,7 @@ class SaveReportTest(TestCase):
         utils.save_report(request)
 
         report = CSPReport.objects.first()
-        self.assertQuerysetEqual(report.user_agent, '')
+        self.assertQuerySetEqual(report.user_agent, '')
 
     def test_save_report_correct_format_missing_mandatory_fields(self):
         """ Test that the `save_report` saves CSPReport instance even if some required CSP Report
@@ -214,7 +214,7 @@ class SaveReportTest(TestCase):
         utils.save_report(request)
 
         reports = CSPReport.objects.all()
-        self.assertQuerysetEqual(reports.values_list('user_agent'), [('Agent007', )], transform=tuple)
+        self.assertQuerySetEqual(reports.values_list('user_agent'), [('Agent007', )], transform=tuple)
         report = reports[0]
         self.assertEqual(report.json, json.dumps(body))
         self.assertTrue(report.is_valid)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 import os
 
 PACKAGES = find_packages()
-REQUIREMENTS = ['django >=2.2,<5.0']
+REQUIREMENTS = ['django >=2.2,<5.3']
 TEST_REQUIREMENTS = ['coverage']
 EXTRAS_REQUIRE = {
     'quality': ['isort', 'flake8'],

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist =
     py37-{22,30}
     py38-{22,30,40}
     py39-{30,40}
-    py310-{30,40}
+    py310-{30,40,50}
 
 # tox-travis block: mark quality as part of the python3.10 build
 [travis]
@@ -20,6 +20,7 @@ deps =
     22: django >= 2.2.8, < 2.3
     30: django >= 3.0.5, <4.0
     40: django >= 4.0, <5.0
+    50: django >= 5.0, <5.3
 extras = test
 passenv = CI TRAVIS TRAVIS_*
 setenv = DJANGO_SETTINGS_MODULE = cspreports.tests.settings


### PR DESCRIPTION
Heya, have made some tweaks to be able to support django 5.2, let me know if there's anything else that might be needed.

- Bumps django version in setup.
- Changes references of removed `timezone.utc` to `datetime.timezone.utc`
- Changes references to removed `assertQuerysetEqual` to `assertQuerySetEqual`
- Modifies a test that looks at `line_number` validation. In django versions >5 the connection returns a min value of 0 for `PositiveIntegerField` so testing with a value of -666 will result in the form not being valid, but in 4.2 it returns as valid.